### PR TITLE
メイドが主人に追従する手段のうち、テレポートを禁止できるようにする

### DIFF
--- a/common/src/main/java/net/sistr/littlemaidrebirth/config/LMRBConfig.java
+++ b/common/src/main/java/net/sistr/littlemaidrebirth/config/LMRBConfig.java
@@ -78,7 +78,7 @@ public class LMRBConfig implements ConfigData {
     private float sprintEndRange = 6.0f;
 
     @ConfigEntry.Category("maid")
-    private boolean enableTeleport = true;
+    private boolean allowTeleporting = true;
 
     @ConfigEntry.Category("maid")
     private float teleportStartRange = 16.0f;
@@ -221,9 +221,7 @@ public class LMRBConfig implements ConfigData {
         return sprintEndRange;
     }
 
-    public boolean isEnableTeleport() {
-        return enableTeleport;
-    }
+    public boolean isAllowedToTeleport() { return allowTeleporting; }
 
     public float getTeleportStartRange() {
         return teleportStartRange;

--- a/common/src/main/java/net/sistr/littlemaidrebirth/config/LMRBConfig.java
+++ b/common/src/main/java/net/sistr/littlemaidrebirth/config/LMRBConfig.java
@@ -78,6 +78,9 @@ public class LMRBConfig implements ConfigData {
     private float sprintEndRange = 6.0f;
 
     @ConfigEntry.Category("maid")
+    private boolean enableTeleport = true;
+
+    @ConfigEntry.Category("maid")
     private float teleportStartRange = 16.0f;
 
     @ConfigEntry.Category("maid")
@@ -216,6 +219,10 @@ public class LMRBConfig implements ConfigData {
 
     public float getSprintEndRange() {
         return sprintEndRange;
+    }
+
+    public boolean isEnableTeleport() {
+        return enableTeleport;
     }
 
     public float getTeleportStartRange() {

--- a/common/src/main/java/net/sistr/littlemaidrebirth/config/LMRBConfig.java
+++ b/common/src/main/java/net/sistr/littlemaidrebirth/config/LMRBConfig.java
@@ -221,7 +221,9 @@ public class LMRBConfig implements ConfigData {
         return sprintEndRange;
     }
 
-    public boolean isAllowedToTeleport() { return allowTeleporting; }
+    public boolean isAllowedToTeleport() {
+        return allowTeleporting;
+    }
 
     public float getTeleportStartRange() {
         return teleportStartRange;

--- a/common/src/main/java/net/sistr/littlemaidrebirth/entity/LittleMaidEntity.java
+++ b/common/src/main/java/net/sistr/littlemaidrebirth/entity/LittleMaidEntity.java
@@ -230,12 +230,12 @@ public class LittleMaidEntity extends TameableEntity implements EntitySpawnExten
                 config.getTeleportStartRange()) {
             @Override
             public boolean canStart() {
-                return (config.isEnableTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && super.canStart();
+                return (config.isAllowedToTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && super.canStart();
             }
 
             @Override
             public boolean shouldContinue() {
-                return (config.isEnableTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && super.shouldContinue();
+                return (config.isAllowedToTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && super.shouldContinue();
             }
         });
         //緊急テレポート
@@ -244,12 +244,12 @@ public class LittleMaidEntity extends TameableEntity implements EntitySpawnExten
                         config.getEmergencyTeleportStartRange()) {
                     @Override
                     public boolean canStart() {
-                        return (config.isEnableTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && isEmergency() && super.canStart();
+                        return (config.isAllowedToTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && isEmergency() && super.canStart();
                     }
 
                     @Override
                     public boolean shouldContinue() {
-                        return (config.isEnableTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && isEmergency() && super.shouldContinue();
+                        return (config.isAllowedToTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && isEmergency() && super.shouldContinue();
                     }
                 });
 

--- a/common/src/main/java/net/sistr/littlemaidrebirth/entity/LittleMaidEntity.java
+++ b/common/src/main/java/net/sistr/littlemaidrebirth/entity/LittleMaidEntity.java
@@ -227,19 +227,29 @@ public class LittleMaidEntity extends TameableEntity implements EntitySpawnExten
         LMRBConfig config = LMRBMod.getConfig();
 
         this.goalSelector.add(++priority, new HasMMTeleportTameOwnerGoal<>(this,
-                config.getTeleportStartRange()));
+                config.getTeleportStartRange()) {
+            @Override
+            public boolean canStart() {
+                return (config.isEnableTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && super.canStart();
+            }
+
+            @Override
+            public boolean shouldContinue() {
+                return (config.isEnableTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && super.shouldContinue();
+            }
+        });
         //緊急テレポート
         this.goalSelector.add(priority,
                 new HasMMTeleportTameOwnerGoal<>(this,
                         config.getEmergencyTeleportStartRange()) {
                     @Override
                     public boolean canStart() {
-                        return isEmergency() && super.canStart();
+                        return (config.isEnableTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && isEmergency() && super.canStart();
                     }
 
                     @Override
                     public boolean shouldContinue() {
-                        return isEmergency() && super.shouldContinue();
+                        return (config.isEnableTeleport() || tameable.isTouchingWater() || tameable.isInLava()) && isEmergency() && super.shouldContinue();
                     }
                 });
 

--- a/common/src/main/resources/assets/littlemaidrebirth/lang/en_us.json
+++ b/common/src/main/resources/assets/littlemaidrebirth/lang/en_us.json
@@ -50,6 +50,7 @@
   "text.autoconfig.littlemaidrebirth.option.followEndRange": "Follow End Range",
   "text.autoconfig.littlemaidrebirth.option.sprintStartRange": "Sprint Start Range",
   "text.autoconfig.littlemaidrebirth.option.sprintEndRange": "Sprint Start Range",
+  "text.autoconfig.littlemaidrebirth.option.allowTeleporting": "Allow Teleporting",
   "text.autoconfig.littlemaidrebirth.option.teleportStartRange": "Teleport Start Range",
   "text.autoconfig.littlemaidrebirth.option.emergencyTeleportStartRange": "Emergency Teleport Start Range",
   "text.autoconfig.littlemaidrebirth.option.friendlyFire": "Friendly Fire",

--- a/common/src/main/resources/assets/littlemaidrebirth/lang/ja_jp.json
+++ b/common/src/main/resources/assets/littlemaidrebirth/lang/ja_jp.json
@@ -50,6 +50,7 @@
   "text.autoconfig.littlemaidrebirth.option.followEndRange": "追従終了範囲",
   "text.autoconfig.littlemaidrebirth.option.sprintStartRange": "走行開始範囲",
   "text.autoconfig.littlemaidrebirth.option.sprintEndRange": "走行終了範囲",
+  "text.autoconfig.littlemaidrebirth.option.allowTeleporting": "テレポートを許可",
   "text.autoconfig.littlemaidrebirth.option.teleportStartRange": "テレポート開始範囲",
   "text.autoconfig.littlemaidrebirth.option.emergencyTeleportStartRange": "緊急テレポート開始範囲",
   "text.autoconfig.littlemaidrebirth.option.friendlyFire": "フレンドリーファイアできるか",


### PR DESCRIPTION
身長程度の深さの水に入ると、(動物と同様に)水面で立ち尽くす振る舞いをしたため、例外として除外しています。